### PR TITLE
fix: Support Pydantic v2 via shims.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.7"
 
 urllib3 = ">= 1.25.3"
 python-dateutil = ">=2.8.2"
-pydantic = "^1.10.5, <2"
+pydantic = ">=1.10.5, < 3"
 aenum = ">=3.1.11"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
-pydantic >= 1.10.5, < 2
+pydantic >=1.10.5, < 3
 aenum >= 3.1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
-pydantic >=1.10.5, < 3
+pydantic >= 1.10.5, < 3
 aenum >= 3.1.11

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
     "urllib3 >= 1.25.3, < 2.1.0",
     "python-dateutil",
-    "pydantic >= 1.10.5, < 2",
+    "pydantic >= 1.10.5, < 3",
     "aenum"
 ]
 

--- a/weheat/api/energy_log_api.py
+++ b/weheat/api/energy_log_api.py
@@ -16,12 +16,14 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import Field, StrictStr, validate_arguments
+except ImportError:
+    from pydantic import Field, StrictStr, validate_arguments
+
 
 from typing_extensions import Annotated
 from datetime import datetime
-
-from pydantic import Field, StrictStr
 
 from typing import List, Optional
 

--- a/weheat/api/heat_pump_api.py
+++ b/weheat/api/heat_pump_api.py
@@ -16,10 +16,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, Field, StrictInt, StrictStr
+except ImportError:
+    from pydantic import validate_arguments, Field, StrictInt, StrictStr
 
 from typing_extensions import Annotated
-from pydantic import Field, StrictInt, StrictStr
 
 from typing import List, Optional
 

--- a/weheat/api/heat_pump_log_api.py
+++ b/weheat/api/heat_pump_log_api.py
@@ -16,12 +16,13 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, Field, StrictStr
+except ImportError:
+    from pydantic import validate_arguments, Field, StrictStr
 
 from typing_extensions import Annotated
 from datetime import datetime
-
-from pydantic import Field, StrictStr
 
 from typing import List, Optional
 

--- a/weheat/api/user_api.py
+++ b/weheat/api/user_api.py
@@ -17,9 +17,9 @@ import io
 import warnings
 
 try:
-    from pydantic.v1 import validate_arguments, Field, StrictInt, StrictStr
+    from pydantic.v1 import validate_arguments, Field, StrictStr
 except ImportError:
-    from pydantic import validate_arguments, Field, StrictInt, StrictStr
+    from pydantic import validate_arguments, Field, StrictStr
 
 from typing_extensions import Annotated
 

--- a/weheat/api/user_api.py
+++ b/weheat/api/user_api.py
@@ -16,10 +16,12 @@ import re  # noqa: F401
 import io
 import warnings
 
-from pydantic import validate_arguments, ValidationError
+try:
+    from pydantic.v1 import validate_arguments, Field, StrictInt, StrictStr
+except ImportError:
+    from pydantic import validate_arguments, Field, StrictInt, StrictStr
 
 from typing_extensions import Annotated
-from pydantic import Field, StrictStr
 
 from typing import Optional
 

--- a/weheat/api_response.py
+++ b/weheat/api_response.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import Field, StrictInt, StrictStr
+
+try:
+    from pydantic.v1 import Field, StrictInt, StrictStr
+except ImportError:
+    from pydantic import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """

--- a/weheat/models/energy_view_dto.py
+++ b/weheat/models/energy_view_dto.py
@@ -19,7 +19,10 @@ import json
 
 from datetime import datetime
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
 
 class EnergyViewDto(BaseModel):
     """

--- a/weheat/models/heat_pump_log_view_dto.py
+++ b/weheat/models/heat_pump_log_view_dto.py
@@ -19,7 +19,10 @@ import json
 
 from datetime import datetime
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictFloat, StrictInt, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictFloat, StrictInt, StrictStr
 
 class HeatPumpLogViewDto(BaseModel):
     """

--- a/weheat/models/raw_heat_pump_log_dto.py
+++ b/weheat/models/raw_heat_pump_log_dto.py
@@ -19,7 +19,11 @@ import json
 
 from datetime import datetime
 from typing import Optional, Union
-from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictBool, StrictFloat, StrictInt, StrictStr
+
 
 class RawHeatPumpLogDto(BaseModel):
     """

--- a/weheat/models/read_all_heat_pump_dto.py
+++ b/weheat/models/read_all_heat_pump_dto.py
@@ -19,7 +19,10 @@ import json
 
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, constr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, constr
 from weheat.models.boiler_type import BoilerType
 from weheat.models.device_state import DeviceState
 from weheat.models.dhw_type import DhwType

--- a/weheat/models/read_heat_pump_dto.py
+++ b/weheat/models/read_heat_pump_dto.py
@@ -19,7 +19,10 @@ import json
 
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr, constr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr, constr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr, constr
 from weheat.models.boiler_type import BoilerType
 from weheat.models.device_state import DeviceState
 from weheat.models.dhw_type import DhwType

--- a/weheat/models/read_user_dto.py
+++ b/weheat/models/read_user_dto.py
@@ -19,7 +19,10 @@ import json
 
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, Field, StrictStr
+try:
+    from pydantic.v1 import BaseModel, Field, StrictStr
+except ImportError:
+    from pydantic import BaseModel, Field, StrictStr
 from weheat.models.role import Role
 
 class ReadUserDto(BaseModel):


### PR DESCRIPTION
Weheat is a dependency from HA, so this PR tries to make it compatible with multiple versions of Pydantic to help with the upgrade described in https://github.com/home-assistant/core/issues/99218.

I'm aware that the files are auto-generated, but the OpenAPI generator seems to [support either pydantic v1 or v2](https://openapi-generator.tech/docs/generators), not the backwards compatible version. I'd suggest first generating a release with the backwards compatible version, the doing an upgrade to the version two at some point in the future.

There are no tests on the repo, so I did basic import testing with a dockerfile:

```Dockerfile
FROM python:3.12

WORKDIR /app
COPY . /app
RUN pip install .
RUN python -c "from weheat import *"
```
