### PR TITLE
Add total energy aggregate to raw_content property

### DIFF
--- a/weheat/abstractions/heat_pump.py
+++ b/weheat/abstractions/heat_pump.py
@@ -123,9 +123,12 @@ class HeatPump:
 
     @property
     def raw_content(self) -> Optional[dict]:
-        if self._last_log is not None:
-            return vars(self._last_log)  # type: ignore[unreachable]
-        return None
+        raw = {}
+        if self._last_log:
+            raw.update(vars(self._last_log))
+        if self._energy_total:
+            raw.update(vars(self._energy_total))
+        return raw or None
 
     @property
     def water_inlet_temperature(self) -> Union[float, None]:


### PR DESCRIPTION
This adds the fields of TotalEnergyAggregate to the raw_content (if available) of the heatpump abstraction.
This makes the code raw_content property in line with the capability of the class (either heatpump log or total energy).

Other potential solution:
Create a new property for TotalEnergyAggregate

Reason:
Creating a Domoticz plugin where:
1. A function in the plugin start method can import the energy history (on a per day basis) from a start date
2. Retrieval of the total is appended to the same sensor on a 15 minute poll basis

The issue is that the naming used in the raw_content is consistent with the separate API responses, but inconsistent with the name of @property functions in the  Heatpump abstraction. Being able to get the raw values by name prevents code duplication.
(Meaning creating a local copy of this class to translate the import energy log API call to the same @property names used in this abstraction.